### PR TITLE
fix to show Full Nickname

### DIFF
--- a/src/core/js/cryptocat.js
+++ b/src/core/js/cryptocat.js
@@ -347,6 +347,7 @@ Cryptocat.addBuddy = function(nickname, id, status) {
 	$('#buddyList').queue(function() {
 		var buddyTemplate = Mustache.render(Cryptocat.templates.buddy, {
 			buddyID: buddy.id,
+			fullNickname:nickname,
 			shortNickname: shortenString(nickname, 11),
 			status: status
 		})

--- a/src/core/js/etc/templates.js
+++ b/src/core/js/etc/templates.js
@@ -12,7 +12,7 @@ Cryptocat.templates = {
 	catFact: '<br />Here is an interesting fact while you wait:'
 		+ '<br /><div id="interestingFact">{{catFact}}</div>',
 
-	buddy: '<div class="buddy" id="buddy-{{buddyID}}" status="{{status}}" data-id="{{buddyID}}" dir="ltr">'
+	buddy: '<div class="buddy" id="buddy-{{buddyID}}" status="{{status}}" data-id="{{buddyID}}" title="{{fullNickname}}" dir="ltr">'
 		+ '<span class="loginTypeIcon"></span><span class="shortNickname">{{shortNickname}}</span>'
 		+ '<div class="buddyMenu" id="menu-{{buddyID}}"></div></div>',
 


### PR DESCRIPTION
Names are reduced to 11 characters, this if two buddies have similar names, causes confusion for the user:
As reported here: https://github.com/cryptocat/cryptocat/issues/706
This fix adds a html title attribute to each buddy in the buddyList, hence full nick name can be seen when mouse is hovered on the buddy nickname

Tested on chrome 41 and firefox 35(both firefox and firefox developer edition)