### PR TITLE
Punctuation and chiffrer/crypter usage correction, fixing #708

### DIFF
--- a/src/core/locale/fr.txt
+++ b/src/core/locale/fr.txt
@@ -1,8 +1,8 @@
 ltr
 "Helvetica Neue", Helvetica, Arial, Verdana
 Conversations privées pour tout le monde.
-Bienvenue chez Cryptocat. Voici quelques conseils utiles: <ul><li>Cryptocat n'est pas une solution miracle. Vous ne devriez jamais faire confiance à n'importe quel logiciel dans votre vie.</li><li class="key">Cryptocat ne peut pas vous protéger contre les personnes malhonnêtes ou les enregistreurs de frappe, et ne rend pas votre connexion anonyme.</li></ul>
-Blog
+Bienvenue chez Cryptocat. Voici quelques conseils utiles : <ul><li>Cryptocat n'est pas une solution miracle. Vous ne devriez jamais faire confiance à n'importe quel logiciel dans votre vie.</li><li class="key">Cryptocat ne peut pas vous protéger contre les personnes malhonnêtes ou les enregistreurs de frappe, et ne rend pas votre connexion anonyme.</li></ul>
+Blogue
 Serveur dédié
 Réinitialiser
 nom de la conversation
@@ -11,9 +11,9 @@ connexion
 Entrez un nom pour votre conversation et envoyez-le aux gens avec qui vous souhaitez parler, ou rejoignez <strong>lobby</strong> pour faire de nouvelles rencontres.
 Saisissez le nom d'une conversation à rejoindre.
 Entrez un nom de conversation s'il vous plaît.
-Nom de conversation doit être des lettres ou des chiffres.
+Le nom de conversation doit être des lettres ou des chiffres uniquement.
 Entrez un pseudonyme s'il vous plaît.
-Votre pseudonyme doit être des lettres ou des chiffres.
+Votre pseudonyme doit être des lettres ou des chiffres uniquement.
 Ce pseudonyme est déjà utilisé.
 Erreur d'authentification.
 La connexion a échoué.
@@ -24,13 +24,13 @@ Connecté.
 Veuillez taper sur votre clavier d'une manière aléatoire pendant quelques secondes.
 Génération des clés de chiffrement...
 Conversation de groupe. Cliquez sur un utilisateur pour commencer une conversation privée.
-Signature OTR (pour les conversations privées):
-Signature de la conversation de groupe:
+Signature OTR (pour les conversations privées) :
+Signature de la conversation de groupe :
 Réinitialiser mes clés de chiffrement
 Réinitialiser vos clés de chiffrement va vous déconnecter. Vos signatures seront également modifiées.
 Continuer
-État: Disponible
-État: Absent
+État : Disponible
+État : Absent
 Mes Informations
 Notifications Activées
 Notifications Désactivées
@@ -44,9 +44,9 @@ Envoyer un fichier chiffré
 afficher l'image
 télécharger le fichier
 Conversation
-Seuls les fichiers ZIP et les images sont acceptés. Taille maximale: (SIZE) Mo.
+Seuls les fichiers ZIP et les images sont acceptés. Taille maximale : (SIZE) Mio.
 Erreur: Veuillez vérifier que le fichier soit bien un ZIP ou une image.
-Erreur: Le fichier ne peut pas dépasser (SIZE) Mo.
+Erreur : Le fichier ne peut pas dépasser (SIZE) Mio.
 Démarrer la visioconférence
 Terminer la visioconférence
 (NICKNAME) voudrait démarrer une visioconférence avec vous.
@@ -54,34 +54,34 @@ Annuler
 Ignorer
 Ne pas ignorer
 Authentifier
-Vérifiez l'identité de l'utilisateur en posant une question secrète. Les réponses doivent correspondre exactement!
+Vérifiez l'identité de l'utilisateur en posant une question secrète. Les réponses doivent correspondre exactement !
 Question secrète
 Réponse secrète
 Demander
 Demande en cours...
 Échec
 Identité vérifiée.
-(NICKNAME) veut vérifier votre identité. Veuillez répondre à la question secrète ci-dessous pour vous authentifier:
+(NICKNAME) veut vérifier votre identité. Veuillez répondre à la question secrète ci-dessous pour vous authentifier :
 Votre réponse doit correspondre exactement à celle donnée par (NICKNAME).
 Réponse
-Attention: Vous avez reçu un message illisible de (NICKNAME). Cela peut signifier que l'utilisateur n'est pas de confiance ou que certains messages n'ont pas été bien reçus. Il se peut aussi que vous utilisiez une ancienne version de Cryptocat. Veuillez vérifier s'il existe une mise à jour.
-Attention: Votre version de Cryptocat n'est plus à jour. Une mise à jour avec la dernière version est fortement recommandée! N'allez pas plus loin sans avoir mis à jour avec la dernière version.
-Attention: ce message n'a pas pu être transmis à (NICKNAME)
+Attention : Vous avez reçu un message illisible de (NICKNAME). Cela peut signifier que l'utilisateur n'est pas de confiance ou que certains messages n'ont pas été bien reçus. Il se peut aussi que vous utilisiez une ancienne version de Cryptocat. Veuillez vérifier s'il existe une mise à jour.
+Attention : Votre version de Cryptocat n'est plus à jour. Une mise à jour avec la dernière version est fortement recommandée ! N'allez pas plus loin sans avoir mis à jour avec la dernière version.
+Attention : ce message n'a pas pu être transmis à (NICKNAME)
 Authentifié
 L'utilisateur n'est pas authentifié.
 Cliquez pour en savoir plus...
 En savoir plus sur l'authentification
-A chaque fois que vous avez une conversation via Cryptocat, vous devez authentifier les personnes avec lesquelles vous parler.
+À chaque fois que vous avez une conversation via Cryptocat, vous devez authentifier les personnes avec lesquelles vous parlez.
 Une façon de s'authentifier est de poser une question secrète via Cryptocat à votre ami dont il est le seul à connaître la réponse.
-Vous pouvez aussi les contacter via un canal de communication de confiance, comme par téléphone, et lui demander de lire son fingerprint/son empreinte.
-Les empreintes digitales sont des identifiants qui vous permettent d'authentifier les personnes. Elles peuvent changer entre chaque conversation.
+Vous pouvez aussi les contacter via un canal de communication de confiance, comme par téléphone, et lui demander de lire son son empreinte (fingerprint).
+Les empreintes sont des identifiants qui vous permettent d'authentifier les personnes. Elles peuvent changer entre chaque conversation.
 Sans authentification, quelqu'un pourrait se faire passer pour vous ou intercepter vos communications.
 L'empreinte d'authentification pour ce contact a changée. Ce n'est pas censé se produire et pourrait indiquer un comportement suspect. S'il vous plaît, veuillez authentifier ce contact avant de discuter avec lui.
 Conversation de Groupe
 Facebook
-Connectez-vous à Facebook Chat via Cryptocat. Mettez en place des chats cryptés avec vos amis Facebook qui utilisent Cryptocat aussi.
+Connectez-vous à Facebook Chat via Cryptocat. Mettez en place des conversations chiffrées avec vos amis Facebook qui utilisent également Cryptocat.
 Discuter via Facebook
 État de la conversation
-cryptée.
-pas cryptée!
-Cette conversation n'est pas cryptée car ce contact  n'utilise pas Cryptocat. Demandez à votre ami de télécharger Cryptocat pour profiter d'une conversation cryptée.
+chiffrée.
+non chiffrée !
+Cette conversation n'est pas chiffrée car ce contact  n'utilise pas Cryptocat. Demandez à votre ami de télécharger Cryptocat pour profiter d'une conversation chiffrée.


### PR DESCRIPTION
I've made some changes, first to fix the crypté/chiffré confusion, and also for punctuations.

Indeed, French "double" punctuation requires a space before and after the punctuation sign (; : ! ?), even though it should be a normal space after and a fine non-breaking space before. I've added a normal non-breaking space before those signs, which will be good enough.