### PR TITLE
Simplify local development environment setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ This is the build environment. The actual client source code is located in `src`
 
 Install dependencies:
 ```
-npm install -g electron-prebuilt grunt-cli
-npm install
-cd src
-npm install
-cd ..
+npm run setup
+```
+
+Run:
+```
+npm run dev
 ```
 
 Build for your platform (builds are in `dist`):
 ```
-grunt win
-grunt linux
-grunt mac
+npm run win
+npm run linux
+npm run  mac
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -17,5 +17,12 @@
     "grunt-exec": "latest",
     "azure-storage": "latest",
     "grunt-string-replace": "latest"
+  },
+  "scripts": {
+    "setup": "npm install; cd src; npm install",
+    "dev": "electron src/app.js",
+    "win": "grunt win",
+    "mac": "grunt mac",
+    "linux": "grunt linux"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -3,9 +3,6 @@
   "version": "3.0.30",
   "description": "Easy and secure instant messaging.",
   "main": "app.js",
-  "scripts": {
-    "start": "electron app.js"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cryptocat/cryptocat"


### PR DESCRIPTION
Avoid needing to install global npm packages by calling all `bin`'s via npm scripts. Includes a `setup` npm script to handle the nested `npm install` along with the top level one. Includes a `dev` script so the
developer can stay in the top level directory for all tasks. Expose grunt tasks as npm tasks as well, to avoid installing global `grunt-cli` as well as allowing implementation to switch away from Grunt in the future if desired.