### PR TITLE
Desktop client uses web register, making docs reflect that.

### DIFF
--- a/website/help.html
+++ b/website/help.html
@@ -112,7 +112,7 @@
 			</p>
 			Aside from non-sensitive information such as your notification settings, your device information contains the following sensitive details:
 			<ul>
-				<li><em>Your identity keys</em>: A thief with access to those keys could impersonate this device in the future, but will <em>not</em> be able to decrypt your past Cryptocat conversations, thanks to Cryptocat's forward secrecy feature.</li>
+				<li><em>Your identity keys</em>: A thief with access to those keys could impersonate this device in the future, but will <em>not</em> be able to decrypt your past Cryptocat conversations, thanks to Cryptocat's forward security feature.</li>
 				<li><em>Your username</em>: A thief will be able to learn your Cryptocat username.</li>
 				<li><em>Your buddy list</em>: A thief will be able to learn the contents of your Cryptocat buddy list.</li>
 			</ul>

--- a/website/help.html
+++ b/website/help.html
@@ -60,6 +60,7 @@
 			<h2 id="creatingAccount">Creating an Account</h2>
 			<p>
 				Creating an account can be accomplished from the Cryptocat client's login screen, by clicking the <em>Create Account</em> button.<br />
+				Alternatively you can also sign up <a href="https://crypto.cat/create">here</a>.<br />
 				You can also change your account password by clicking on <em>Account</em> &gt; <em>Change Password</em> in the Cryptocat menu bar.
 			</p>
 			<hr />


### PR DESCRIPTION
The desktop user interface simply opens a new tab to crypto.cat/chat

I updated the help docs to show users they can create an account there.