### PR TITLE
fix formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ npm install -g electron-builder
 build -w
 ```
 #### Linux
-````
+```
 build -l
-````
+```
 #### Mac
-````
+```
 build -m
 ```


### PR DESCRIPTION
There were too many backticks, packaging for Mac has ``` on a separate line.