### PR TITLE
Remove stickers category

### DIFF
--- a/website/ca.html
+++ b/website/ca.html
@@ -45,7 +45,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="security.html">Security</a>
 			<a href="help.html">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/fr.html
+++ b/website/fr.html
@@ -48,7 +48,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="security.html">Sécurité</a>
 			<a href="help.html">Aide</a>
-			<a href="stickers">Autocollants</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/help.html
+++ b/website/help.html
@@ -33,7 +33,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="security.html">Security</a>
 			<a href="#" class="current">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/index.html
+++ b/website/index.html
@@ -48,7 +48,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="security.html">Security</a>
 			<a href="help.html">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/mission.html
+++ b/website/mission.html
@@ -41,7 +41,6 @@
 			<a href="#" class="current">Mission</a>
 			<a href="security.html">Security</a>
 			<a href="help.html">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/news.html
+++ b/website/news.html
@@ -33,7 +33,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="security.html">Security</a>
 			<a href="help.html">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/security.html
+++ b/website/security.html
@@ -33,7 +33,6 @@
 			<a href="mission.html">Mission</a>
 			<a href="#" class="current">Security</a>
 			<a href="help.html">Help</a>
-			<a href="stickers">Stickers</a>
 			<a href="https://github.com/cryptocat/cryptocat">Code</a>
 		</div>
 	</div>

--- a/website/stickers/index.html
+++ b/website/stickers/index.html
@@ -1,7 +1,0 @@
-<html>
-<head>
-<meta http-equiv="refresh" content="0; url=https://www.stickermule.com/marketplace/14386-cryptocat-sticker">
-</head>
-<body>
-</body>
-</html>


### PR DESCRIPTION
Stickermule doesn't accept new orders anymore, so "Stickers" URL doesn't lead anywhere.